### PR TITLE
Replace manual tarpaulin install in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo install cargo-tarpaulin
-      - run: cargo tarpaulin
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 Manage encrypted secrets for your applications.
 
 ## Installation
+
 ```sh
 cargo install street-cred
 ```


### PR DESCRIPTION
In order to speed up tests, this commit replaces manually installing tarpaulin with a github action that downloads a precompiled binary and runs tarpaulin for us.