### PR TITLE
Add additional documentation for library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "street-cred"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "street-cred"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Endoze <endoze@endozemedia.com>"]
 license = "MIT"

--- a/src/encryption/cipher_generation.rs
+++ b/src/encryption/cipher_generation.rs
@@ -1,6 +1,6 @@
 use rand::RngCore;
 
-// Struct used to house cipher data generation.
+/// Collection of functions that generate random data for encryption/decryption.
 pub struct CipherGeneration {}
 
 impl CipherGeneration {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,52 @@
+//! Manage encrypted secrets for your applications.
+//!
+//! street-cred provides the means to encrypt/decrypt files and data through both a cli
+//! tool and as a library.
+//!
+//! # Quickstart (CLI)
+//!
+//! Navigate to a directory where you'd like to have encrypted secrets stored and
+//! use the following command to generate an encrypted secrets file.
+//!
+//! ``` sh
+//! street-cred init
+//! ```
+//!
+//! This will create two files for you. The first is `credentials.yml.enc`, which stores your
+//! secrets encrypted. You can safely rename this file as needed. The second file generated is
+//! your `master.key`. This is your encryption key, protect it like a password!
+//!
+//! To edit your encrypted secrets, use the following command.
+//!
+//! ```sh
+//! street-cred edit credentials.yml.enc
+//! ```
+//!
+//! This should open your secrets file unecrypted in your EDITOR. If you don't have an editor
+//! set, it will default to vim for editing your secrets. Upon saving and closing your editor,
+//! the contents of your file will be re-encrypted using your encryption key and written out
+//! to disk.
+//!
+//! # Quickstart (Library)
+//!
+//! In order to use street-cred as a library in your own code, you'll need to add street-cred to
+//! your dependencies in Cargo.toml. You can quickly accomplish this by running the following command.
+//!
+//! ```sh
+//! cargo add street-cred
+//! ```
+//!
+//! Once you've added the crate to your project, you can import various parts of it to start encrypting
+//! your data.
+//!
+//! Encrypting/Decrypting files can be accomplished with [FileEncryption].
+//!
+//! Encrypting/Decrypting data directly can be accomplished using [MessageEncryption]. While using
+//! MessageEncryption, you'll need to provide some random data for the encryption process like the
+//! encryption key and initialization vector. street-cred provides a few utility functions for this
+//! data via [CipherGeneration].
+//!
+
 mod encryption;
 mod serialization;
 

--- a/src/serialization/ruby_marshal.rs
+++ b/src/serialization/ruby_marshal.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use thurgood::rc::{from_reader, to_writer, Error, RbAny, RbFields, RbRef};
 
-/// Struct used to house the serialize/deserialize functions.
+/// Collection of functions used for serialize/deserialize in the RubyMarshal format.
 pub struct RubyMarshal {}
 
 impl RubyMarshal {
@@ -17,9 +17,11 @@ impl RubyMarshal {
   /// ```
   /// use street_cred::RubyMarshal;
   ///
-  /// let string = "banana";
+  /// let string = "Peanut Butter Jelly Time";
   ///
   /// let serialized = RubyMarshal::serialize(string);
+  ///
+  /// assert_eq!(b"\x04\x08I\"\x1dPeanut Butter Jelly Time\x06:\x06ET", serialized.unwrap().as_slice());
   /// ```
   pub fn serialize(contents: &str) -> anyhow::Result<Vec<u8>> {
     let mut buffer = Vec::new();
@@ -28,7 +30,7 @@ impl RubyMarshal {
     Ok(buffer)
   }
 
-  /// Deserialize data into the Ruby Marshal format.
+  /// Deserialize data from the Ruby Marshal format.
   ///
   /// # Arguments
   /// * `contents` - Data to deserialize
@@ -41,6 +43,8 @@ impl RubyMarshal {
   /// let data = b"\x04\x08I\"\x1dPeanut Butter Jelly Time\x06:\x06ET";
   ///
   /// let string = RubyMarshal::deserialize(data);
+  ///
+  /// assert_eq!(b"Peanut Butter Jelly Time", string.unwrap().as_slice());
   /// ```
   pub fn deserialize<T>(contents: T) -> anyhow::Result<Vec<u8>>
   where


### PR DESCRIPTION
In order to ensure a better experience when viewing this crate on docs.rs, this commit adds documentation to the lib.rs file. This is the first page a user would land on when navigating to the docs. As such, it should contain more information for the library in general and cli usage.