### PR TITLE
Replace rust-crypto crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,12 +158,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -175,16 +249,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+name = "generic-array"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -194,7 +266,17 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -274,6 +356,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -364,16 +455,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
+name = "polyval"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "predicates"
@@ -445,80 +548,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -566,25 +601,6 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "ryu"
@@ -645,14 +661,13 @@ dependencies = [
 name = "street-cred"
 version = "0.1.1"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "assert_fs",
  "base64",
  "clap",
  "hex",
  "lazy_static",
- "rand 0.8.5",
- "rust-crypto",
  "serde",
  "serde_json",
  "shellexpand",
@@ -664,6 +679,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -750,21 +771,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
+name = "typenum"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "version_check"
@@ -782,12 +808,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,10 @@ serde_json = "1"
 clap = { version = "4.0.4", features = ["derive"] }
 base64 = { version = "0.13.0" }
 hex = { version = "0.4.3" }
-rust-crypto = { version = "0.2.36" }
 shellexpand = { version = "2.1.2" }
 thurgood = { version = "0.2.1" }
-rand = { version = "0.8.5" }
 anyhow = { version = "1.0.65" }
+aes-gcm = "0.10.1"
 
 [dev-dependencies]
 assert_fs = { version = "1.0.7" }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ cargo add street-cred
 Street Cred expects your encryption key to be in an environment variable named `MASTER_KEY` or in a file in the current directory named `master.key`.
 
 ```sh
+# Initialize a new project with an encrypted secrets file and encryption key
+street-cred init
+
 # Edit existing file
 street-cred edit secrets.txt.enc
 ```
@@ -41,8 +44,8 @@ let file_path = String::from("secrets.txt.enc");
 let encryption_key = String::from("425D76994EE6101105DDDA2EE2604AA0");
 let file_encryption = FileEncryption::new(file_path, encryption_key);
 
-if let Some((decrypted_contents, initialization_vector, additional_authenticated_data)) = file_encryption.decrypt() {
-  // do something with decrypted_contents, initialization_vector, additional_authenticated_data
+if let Some(decrypted_contents) = file_encryption.decrypt() {
+  // do something with decrypted_contents
 };
 ```
 

--- a/src/encryption/cipher_generation.rs
+++ b/src/encryption/cipher_generation.rs
@@ -1,4 +1,7 @@
-use rand::RngCore;
+use aes_gcm::{
+  aead::{rand_core::RngCore, KeyInit, OsRng},
+  Aes128Gcm,
+};
 
 /// Collection of functions that generate random data for encryption/decryption.
 pub struct CipherGeneration {}
@@ -29,7 +32,8 @@ impl CipherGeneration {
   /// let key = CipherGeneration::random_key();
   /// ```
   pub fn random_key() -> String {
-    hex::encode(Self::random_bytes(16))
+    let key = Aes128Gcm::generate_key(&mut OsRng);
+    hex::encode(key)
   }
 
   /// Generates a Vec of a specified length filled with random bytes and returns it as a
@@ -40,7 +44,7 @@ impl CipherGeneration {
   ///
   fn random_bytes(length: usize) -> Vec<u8> {
     let mut data = vec![0; length];
-    rand::thread_rng().fill_bytes(&mut data);
+    OsRng.fill_bytes(&mut data);
 
     data
   }

--- a/src/encryption/message_encryptor.rs
+++ b/src/encryption/message_encryptor.rs
@@ -308,8 +308,6 @@ orange: false";
 
     let result = encryptor.encrypt();
 
-    println!("BANANANANANANANANANA: {:#?}", result);
-
     assert!(result.is_err());
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 //! Encrypting/Decrypting files can be accomplished with [FileEncryption].
 //!
 //! Encrypting/Decrypting data directly can be accomplished using [MessageEncryption]. While using
-//! MessageEncryption, you'll need to provide some random data for the encryption process like the
-//! encryption key and initialization vector. street-cred provides a few utility functions for this
+//! MessageEncryption, you'll need to provide some data for the encryption process like the
+//! encryption key and additional authenticated data. street-cred provides a few utility functions for this
 //! data via [CipherGeneration].
 //!
 

--- a/src/serialization/ruby_marshal.rs
+++ b/src/serialization/ruby_marshal.rs
@@ -1,7 +1,5 @@
-#![allow(unused)]
-use anyhow::anyhow;
 use anyhow::Context;
-use thurgood::rc::{from_reader, to_writer, Error, RbAny, RbFields, RbRef};
+use thurgood::rc::{from_reader, to_writer, RbAny, RbRef};
 
 /// Collection of functions used for serialize/deserialize in the RubyMarshal format.
 pub struct RubyMarshal {}
@@ -25,7 +23,7 @@ impl RubyMarshal {
   /// ```
   pub fn serialize(contents: &str) -> anyhow::Result<Vec<u8>> {
     let mut buffer = Vec::new();
-    let bytes_written = to_writer(&mut buffer, &RbAny::from(RbRef::Str(contents.to_string())));
+    let _bytes_written = to_writer(&mut buffer, &RbAny::from(RbRef::Str(contents.to_string())));
 
     Ok(buffer)
   }


### PR DESCRIPTION
In order to ensure we are using up to date and maintained dependencies, this commit removes rust-crypto as it's no longer maintained and replaces it with aes_gcm. Additionally it updates a few tests for clarity of what we are testing.

Finally, it simplifies the public api of FileEncryption. It removes the initialization vector and additional authenticated data from encrypt. This is to ensure compatibility with existing encrypted secrets already generated elsewhere. The initialization vector passed in was unused and it generated it's own internally.