### PR TITLE
chore: Add release-plz configuration

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,27 @@
+[workspace]
+# path of the git-cliff configuration
+changelog_config = "cliff.toml"
+
+# enable changelog updates
+changelog_update = true
+
+# update dependencies with `cargo update`
+dependencies_update = true
+
+# create tags for the releases
+git_tag_enable = true
+
+# disable GitHub releases
+git_release_enable = false
+
+# labels for the release PR
+pr_labels = ["release"]
+
+# disallow updating repositories with uncommitted changes
+allow_dirty = false
+
+# disallow packaging with uncommitted changes
+publish_allow_dirty = false
+
+# disable running `cargo-semver-checks`
+semver_check = false


### PR DESCRIPTION
In order to ensure releases are automatically created and artifacts are built, this commit adds a release-plz configuration file.